### PR TITLE
Update javdatabase.go

### DIFF
--- a/pkg/scrape/javdatabase.go
+++ b/pkg/scrape/javdatabase.go
@@ -25,7 +25,7 @@ func ScrapeJavDB(out *[]models.ScrapedScene, queryString string) {
 
 		// Cast
 		html.ForEach("h2.subhead", func(id int, h2 *colly.HTMLElement) {
-			if h2.Text == "Featured Idols" {
+			if strings.HasSuffix(h2.Text, "Actress/Idols") {
 				dom := h2.DOM
 				parent := dom.Parent()
 				if parent != nil {


### PR DESCRIPTION
scraper: fix JAV Database cast scraping

HTML for scenes on JAVDB changed, "Featured Idols" has been replaced with "ABC-123 Actress/Idols"

no idea if this works right or not, it was ChatGPT's idea